### PR TITLE
update to 0.6.5 and use ignore_run_exports_from

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.4" %}
+{% set version = "0.6.5" %}
 
 package:
   name: micromamba
@@ -6,17 +6,17 @@ package:
 
 source:
   - url: https://github.com/mamba-org/mamba/archive/{{ version }}.tar.gz
-    sha256: 7706d83dfab7cc7cb5bfb6f17806853e0e3b519771cee1c2baccb9a1deb5d586
+    sha256: 70194c6a0e3905b1426004df3f889ae6768559f24037631c644dc9208a072611
   - path: CLI11.hpp
     folder: include/mamba/CLI.hpp
 
 build:
-  number: 1
-  ignore_run_exports:
+  number: 0
+  ignore_run_exports_from:
     - libcurl        # [unix]
     - libarchive     # [unix]
-    - libgcc-ng      # [linux]
-    - libstdcxx-ng   # [linux]
+    - {{ compiler('c') }}      # [linux]
+    - {{ compiler('cxx') }}    # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
