### PR TITLE
Steps required for the next release 

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -35,7 +35,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,6 +20,8 @@ libcurl:
 - '7'
 openssl:
 - 1.1.1
+spdlog:
+- '1.10'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -24,6 +24,8 @@ libcurl:
 - '7'
 openssl:
 - 1.1.1
+spdlog:
+- '1.10'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -20,6 +20,8 @@ libcurl:
 - '7'
 openssl:
 - 1.1.1
+spdlog:
+- '1.10'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/spdlog110.yaml
+++ b/.ci_support/migrations/spdlog110.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1649104681.268471
-spdlog:
-- '1.10'

--- a/.ci_support/migrations/spdlog110.yaml
+++ b/.ci_support/migrations/spdlog110.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1649104681.268471
+spdlog:
+- '1.10'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,6 +22,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
+spdlog:
+- '1.10'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -20,6 +20,8 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - 1.1.1
+spdlog:
+- '1.10'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2019
 fmt:
 - '9'
+spdlog:
+- '1.10'
 target_platform:
 - win-64
 zlib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,42 +32,42 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10117&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/micromamba-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,3 @@
-mkdir build
-cd build
-
 # Conda's binary relocation can result in string changing which can result in errors like
 #    > warning: command substitution: ignored null byte in input
 # https://github.com/mamba-org/mamba/issues/1517
@@ -8,18 +5,17 @@ export CXXFLAGS="${CXXFLAGS} -fno-merge-constants"
 export CFLAGS="${CFLAGS} -fno-merge-constants"
 export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY=1"
 
-cmake ${CMAKE_ARGS} .. \
-         -GNinja \
-         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-         -DCMAKE_BUILD_TYPE="Release" \
-         -DBUILD_LIBMAMBA=ON \
-         -DBUILD_STATIC_DEPS=ON \
-         -DBUILD_MICROMAMBA=ON \
-         -DMICROMAMBA_LINKAGE=FULL_STATIC
-
-ninja
-
-ninja install
+cmake -B build \
+    -G Ninja \
+    ${CMAKE_ARGS} \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D CMAKE_BUILD_TYPE="Release" \
+    -D BUILD_LIBMAMBA=ON \
+    -D BUILD_STATIC_DEPS=ON \
+    -D BUILD_MICROMAMBA=ON \
+    -D MICROMAMBA_LINKAGE=FULL_STATIC
+cmake --build build/ --parallel ${CPU_COUNT}
+cmake --install build/
 
 # remove everything related to `libmamba`
 rm -rf $PREFIX/lib/libmamba*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - libarchive-minimal-static   # [unix]
     - reproc-cpp                  # [unix]
     - openssl                     # [unix]
-    - spdlog 1.10 *_0
+    - spdlog
     - fmt
     - {{ compiler('c') }}         # [linux]
     - {{ compiler('cxx') }}       # [linux]
@@ -40,7 +40,7 @@ requirements:
     - cli11 >=2.2,<3
     - cpp-expected
     - nlohmann_json
-    - spdlog 1.10 *_0
+    - spdlog
     - fmt
     - termcolor-cpp
     - yaml-cpp-static              # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,18 @@ package:
 
 source:
   - url: https://github.com/mamba-org/mamba/archive/refs/tags/micromamba-{{ version }}.tar.gz
+<<<<<<< HEAD
     sha256: 7303d983b49a1a52b302ceae355af1c05afef3a07aa3ad6dd27c36d64c43f991
     patches:
       - libmamba.patch
       - fix_ssl_init.patch
+||||||| parent of 2849d0a (Remove patch)
+    sha256: cb9ed96ac3b2f96553bd6bf6d7b863903d0ab4872e20418199b5caf285791896
+    patches:
+      - libmamba.patch
+=======
+    sha256: cb9ed96ac3b2f96553bd6bf6d7b863903d0ab4872e20418199b5caf285791896
+>>>>>>> 2849d0a (Remove patch)
 
 build:
   number: {{ build_num }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,18 +7,10 @@ package:
 
 source:
   - url: https://github.com/mamba-org/mamba/archive/refs/tags/micromamba-{{ version }}.tar.gz
-<<<<<<< HEAD
     sha256: 7303d983b49a1a52b302ceae355af1c05afef3a07aa3ad6dd27c36d64c43f991
     patches:
       - libmamba.patch
       - fix_ssl_init.patch
-||||||| parent of 2849d0a (Remove patch)
-    sha256: cb9ed96ac3b2f96553bd6bf6d7b863903d0ab4872e20418199b5caf285791896
-    patches:
-      - libmamba.patch
-=======
-    sha256: cb9ed96ac3b2f96553bd6bf6d7b863903d0ab4872e20418199b5caf285791896
->>>>>>> 2849d0a (Remove patch)
 
 build:
   number: {{ build_num }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/mamba-org/mamba/archive/refs/tags/micromamba-{{ version }}.tar.gz
-    sha256: 7303d983b49a1a52b302ceae355af1c05afef3a07aa3ad6dd27c36d64c43f991
+  # To test the latest mamba, do not merge
+  - git_url: https://github.com/mamba-org/mamba.git
     patches:
       - libmamba.patch
-      - fix_ssl_init.patch
 
 build:
   number: {{ build_num }}


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This are necessary for the next release:
 - The `libmamba.patch` got added to libmamba;
 - The spdlog migration from #83 got included
 - Libmamba depends explicitly on `fmt`
 
 Close #83
 
 In the meantime, as of https://github.com/mamba-org/mamba/pull/2055, mamba is pointing to this branch for testing static builds. 