### PR TITLE
Try unexporting all symbols to remove libc++ dynamic link

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,9 +4,15 @@ cd build
 # Conda's binary relocation can result in string changing which can result in errors like
 #    > warning: command substitution: ignored null byte in input
 # https://github.com/mamba-org/mamba/issues/1517
-export CXXFLAGS="${CXXFLAGS} -fno-merge-constants"
-export CFLAGS="${CFLAGS} -fno-merge-constants"
-export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY=1"
+if [[ "$target_platform" == "linux-"* ]]; then
+  export CXXFLAGS="${CXXFLAGS} -fno-merge-constants"
+  export CFLAGS="${CFLAGS} -fno-merge-constants"
+fi
+
+if [[ "$target_platform" == "osx-"* ]]; then
+  export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY=1"
+  export LDFLAGS="${LDFLAGS} -Wl,-unexported-symbol,'*'"
+fi
 
 cmake ${CMAKE_ARGS} .. \
          -GNinja \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ fi
 
 if [[ "$target_platform" == "osx-"* ]]; then
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY=1"
-  export LDFLAGS="${LDFLAGS} -Wl,-unexported-symbol,'*'"
+  export LDFLAGS="${LDFLAGS} -Wl,-unexported_symbol,'*'"
 fi
 
 cmake ${CMAKE_ARGS} .. \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.0" %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 package:
   name: micromamba


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
