### PR TITLE
only enable RawURL update strategy

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,3 +13,7 @@ provider:
   linux_aarch64: default
   linux_ppc64le: default
 test_on_native_only: true
+bot:
+  version_updates:
+    sources:
+    - rawurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.5.1" %}
 {% set sha256 = "8760f5d01f307aad28bf04df9affdc077687594cea175b02a4b5ba20933b0920" %}
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 
 # A strategy for testing the feedstock locally in mamba CI
 {% if os.environ.get("CI", "") == "local" %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Due to the way Mamba structures its tags (https://github.com/mamba-org/mamba/tags), the autotick bot gets confused when using the GitHub strategy and tries to update the package to `2023.10.30`, which fails. This PR forces the bot to only use the RawURL strategy, which tries to find a newer version by raising the major, minor and patch components of the version and does not have the problem of the GitHub strategy.

<!--
Please add any other relevant info below:
-->
