### PR TITLE
Update `vcpkg` repository version and drop `vcpkg-tool` as a `build` dependency

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,14 +3,14 @@ SET VCPKG_ROOT=%CD%\vcpkg
 SET VCPKG_BUILD_TYPE=release
 
 :: Run vcpkg bootstrap script
-call %VCPKG_ROOT%\bootstrap-vcpkg.bat
+CALL %VCPKG_ROOT%\bootstrap-vcpkg.bat
 
 SET VCPKG_EXE=%VCPKG_ROOT%\vcpkg.exe
 
 if %errorlevel% NEQ 0 exit /b %errorlevel%
 %VCPKG_EXE% install "libarchive[bzip2,lz4,lzma,lzo,crypto,zstd]" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%
-%VCPKG_EXE% install "yaml-cpp[build]" --triplet x64-windows-static-md
+%VCPKG_EXE% install "curl" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%
 
 SET "CXXFLAGS=%CXXFLAGS% /showIncludes"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,10 +5,12 @@ SET VCPKG_BUILD_TYPE=release
 :: Run vcpkg bootstrap script
 call %VCPKG_ROOT%\bootstrap-vcpkg.bat
 
+SET VCPKG_EXE=%VCPKG_ROOT%\vcpkg.exe
+
 if %errorlevel% NEQ 0 exit /b %errorlevel%
-vcpkg install "libarchive[bzip2,lz4,lzma,lzo,crypto,zstd]" --triplet x64-windows-static-md
+%VCPKG_EXE% install "libarchive[bzip2,lz4,lzma,lzo,crypto,zstd]" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%
-vcpkg install curl --triplet x64-windows-static-md
+%VCPKG_EXE% install "yaml-cpp[build]" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%
 
 SET "CXXFLAGS=%CXXFLAGS% /showIncludes"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,9 @@ SET VCPKG_ROOT=%CD%\vcpkg
 
 SET VCPKG_BUILD_TYPE=release
 
+:: Run vcpkg bootstrap script
+call %VCPKG_ROOT%\bootstrap-vcpkg.bat
+
 if %errorlevel% NEQ 0 exit /b %errorlevel%
 vcpkg install "libarchive[bzip2,lz4,lzma,lzo,crypto,zstd]" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - cmake
+    - cmake <4
     - ninja
     - python          # [win]
     - curl >=8.4.0    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ requirements:
     - {{ stdlib('c') }}
     - cmake
     - ninja
-    - vcpkg-tool      # [win]
     - python          # [win]
     - curl >=8.4.0    # [win]
     - zlib            # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ source:
     "{{ mamba_hash_type }}": "{{ mamba_hash_val }}"
     folder: mamba
   # VCPKG comes with its own (short-lived) metadata which can be already outdated in the latest release
-  - url: https://github.com/microsoft/vcpkg/archive/refs/tags/2024.07.12.tar.gz  # [win]
-    sha256: 7da785e42b7487fb0e7465188f12c6ce0dfa760ab334d0f4f708bd1fc54081b1     # [win]
+  - url: https://github.com/microsoft/vcpkg/archive/refs/tags/2025.03.19.tar.gz  # [win]
+    sha256: b943a85c6a50cedf4d0d97ff67f96afa4efb28213fd3bad16ff234337eb22f7a     # [win]
     folder: vcpkg  # [win]
 
 build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Bumping the build number is not necessary because the builds for Window has not been published for 2.0.8 due to the failure with vcpkg.

@conda-forge-admin, please rerender