### PR TITLE
Use `conda-forge::zlib`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.6.0" %}
 {% set sha256 = "d3a9eeb7e84c6c107ad40f1e665e38c5af97dac822bd766109988ffbedbcc4a3" %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 # A strategy for testing the feedstock locally in mamba CI
 {% if os.environ.get("CI", "") == "local" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,6 @@ requirements:
     - vcpkg-tool      # [win]
     - python          # [win]
     - curl >=8.4.0    # [win]
-    - zlib            # [win]
   host:
     - cli11 >=2.2,<3
     - cpp-expected
@@ -70,6 +69,7 @@ requirements:
     - reproc-static >=14.2.4.post0
     - reproc-cpp-static >=14.2.4.post0
     - libmsgpack-c-static
+    - zlib
     - libcurl >=8.4.0              # [unix]
     - libcurl-static >=8.4.0       # [unix]
     - xz-static                    # [unix]
@@ -79,7 +79,6 @@ requirements:
     - openssl                      # [unix]
     - libopenssl-static            # [unix]
     - zstd-static                  # [unix]
-    - zlib                         # [unix]
     - libnghttp2-static            # [unix]
     - lz4-c-static                 # [unix]
     - winreg                       # [win]


### PR DESCRIPTION
vcpkg distribution of zlib 1.3.2 comes with CMake failures.

At the same time, `zlib` was (improperly?) specified as a `build` dependencies for Windows in this recipe.

Let's see if we can use `zlib` as a dependency from conda-forge instead of pulling it from `vcpkg`.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

