### PR TITLE
test: maint: Remove `libxml2` as a dependency

### DIFF
--- a/recipe/0001-maint-Remove-libxml2-as-a-dependency.patch
+++ b/recipe/0001-maint-Remove-libxml2-as-a-dependency.patch
@@ -1,0 +1,50 @@
+From 45863ab5447d83fe070394fe6f8eeaa8e14e7def Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Wed, 6 May 2026 12:56:01 +0200
+Subject: [PATCH] maint: Remove `libxml2` as a dependency
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ libmamba/CMakeLists.txt | 4 +---
+ vcpkg.json              | 1 -
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/libmamba/CMakeLists.txt b/libmamba/CMakeLists.txt
+index ef53a772..1a9a3520 100644
+--- a/libmamba/CMakeLists.txt
++++ b/libmamba/CMakeLists.txt
+@@ -598,10 +598,9 @@ macro(libmamba_create_target target_name linkage output_name)
+             find_library(BZIP2_LIBRARIES NAMES bz2)
+             find_library(CRYPTO_LIBRARIES NAMES libcrypto)
+ 
+-            find_library(LIBXML2_LIBRARY NAMES libxml2)
+             find_library(ICONV_LIBRARY NAMES libiconv iconv)
+             find_library(CHARSET_LIBRARY NAMES libcharset charset)
+-            message("Found: ${LIBXML2_LIBRARY} ${ICONV_LIBRARY} ${CHARSET_LIBRARY}")
++            message("Found: ${ICONV_LIBRARY} ${CHARSET_LIBRARY}")
+ 
+             target_link_libraries(
+                 ${target_name}
+@@ -609,7 +608,6 @@ macro(libmamba_create_target target_name linkage output_name)
+                     ${CRYPTO_LIBRARIES}
+                     ${SYSTEM_PROVIDED_LIBRARIES}
+                     ${LibArchive_LIBRARY}
+-                    ${LIBXML2_LIBRARY}
+                     ${ICONV_LIBRARY}
+                     ${CHARSET_LIBRARY}
+                     zstd::libzstd_static
+diff --git a/vcpkg.json b/vcpkg.json
+index 99dce160..a27d6a36 100644
+--- a/vcpkg.json
++++ b/vcpkg.json
+@@ -3,7 +3,6 @@
+   "dependencies": [
+     "curl",
+     "libiconv",
+-    "libxml2",
+     {
+       "name": "winreg",
+       "platform": "windows"
+-- 
+2.54.0
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,8 +14,6 @@ if %errorlevel% NEQ 0 exit /b %errorlevel%
 if %errorlevel% NEQ 0 exit /b %errorlevel%
 %VCPKG_EXE% install "libiconv" --triplet x64-windows-static-md
 if %errorlevel% NEQ 0 exit /b %errorlevel%
-%VCPKG_EXE% install "libxml2" --triplet x64-windows-static-md
-if %errorlevel% NEQ 0 exit /b %errorlevel%
 
 SET "CXXFLAGS=%CXXFLAGS% /showIncludes"
 SET "CXXFLAGS=%CXXFLAGS% /D YAML_CPP_STATIC_DEFINE"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
   - "{{ mamba_source_type }}": "{{ mamba_source_val }}"
     "{{ mamba_hash_type }}": "{{ mamba_hash_val }}"
     folder: mamba
-    patch:
+    patches:
       - 0001-maint-Remove-libxml2-as-a-dependency.patch
   # VCPKG comes with its own (short-lived) metadata which can be already outdated in the latest release
   - url: https://github.com/microsoft/vcpkg/archive/refs/tags/2025.07.25.tar.gz  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,6 @@ requirements:
     - vcpkg-tool      # [win]
     - python          # [win]
     - curl >=8.4.0    # [win]
-    - zlib            # [win]
   host:
     - cli11 >=2.2,<3
     - cpp-expected
@@ -72,6 +71,7 @@ requirements:
     - reproc-static >=14.2.4.post0
     - reproc-cpp-static >=14.2.4.post0
     - libmsgpack-c-static
+    - zlib
     - libcurl >=8.4.0              # [unix]
     - libcurl-static >=8.4.0       # [unix]
     - xz-static                    # [unix]
@@ -81,7 +81,6 @@ requirements:
     - openssl                      # [unix]
     - libopenssl-static            # [unix]
     - zstd-static                  # [unix]
-    - zlib                         # [unix]
     - libnghttp2-static            # [unix]
     - lz4-c-static                 # [unix]
     - winreg                       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.6.0" %}
 {% set sha256 = "d3a9eeb7e84c6c107ad40f1e665e38c5af97dac822bd766109988ffbedbcc4a3" %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 # A strategy for testing the feedstock locally in mamba CI
 {% if os.environ.get("CI", "") == "local" %}
@@ -27,6 +27,8 @@ source:
   - "{{ mamba_source_type }}": "{{ mamba_source_val }}"
     "{{ mamba_hash_type }}": "{{ mamba_hash_val }}"
     folder: mamba
+    patch:
+      - 0001-maint-Remove-libxml2-as-a-dependency.patch
   # VCPKG comes with its own (short-lived) metadata which can be already outdated in the latest release
   - url: https://github.com/microsoft/vcpkg/archive/refs/tags/2025.07.25.tar.gz  # [win]
     sha256: dff617c636a6519d4f083e658d404970c9da7d940a974e1d17f855f26a334e2f     # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
